### PR TITLE
Add support for formality tones

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ deepl --help
 ```
 
 ```
-usage: deepl [-h] [--version] [-t TEXT | -f FILE] source_language target_language
+usage: deepl [-h] [--version] [--formal | --informal] [-t TEXT | -f FILE] source_language target_language
 
 Python client to translate texts using deepl.com
 
@@ -67,6 +67,8 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   --version             show program's version number and exit
+  --formal              Use formal tone in translation
+  --informal            Use informal tone in translation
   -t TEXT, --text TEXT  Text to be translated
   -f FILE, --file FILE  File to be translated
 ```
@@ -85,15 +87,43 @@ deepl spanish russian -t "¡Buenos días!"
 
 #### Example 2
 
-This will translate a the file (```test.txt```) text from Italian (```IT```) into Portuguese (```PT```):
+This will translate the file (```test.txt```) text from Italian (```IT```) into Portuguese (```PT```):
 
 ```bash
 deepl IT PT --file test.txt
 ```
 
+#### Example 3
+
+This will translate a Spanish (```ES```) text into Russian (```RU```) in _formal_ tone:
+
+```bash
+deepl ES RU --text "¿Cómo te llamas?" --formal
+```
+
+```
+Как Вас зовут?
+```
+
+Note: _informal_ would be "_Как **тебя** зовут?_"
+
+#### Example 4
+
+This will translate a Japanese (```JP```) text into German (```DE```) in _informal_ tone:
+
+```bash
+deepl JP DE --text "お元気ですか？" --informal
+```
+
+```
+Wie geht es dir?
+```
+
+Note: _formal_ would be "_Wie geht es **Ihnen**?_"
+
 ### Python library
 
-#### Example
+#### Example 1
 
 This will translate a Chinese (```ZH```) text into Dutch (```NL```):
 
@@ -103,5 +133,18 @@ deepl.translate(source_language="ZH", target_language="NL", text="你好")
 ```
 
 ```
-'Hallo.'
+'Hallo'
+```
+
+#### Example 2
+
+This will translate a ```danish``` text into ```german``` in informal tone:
+
+```python
+import deepl
+deepl.translate(source_language="danish", target_language="german", text="Ring til mig!", formality_tone="informal")
+```
+
+```
+'Ruf mich an!'
 ```

--- a/deepl/__init__.py
+++ b/deepl/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 from .api import translate

--- a/deepl/__main__.py
+++ b/deepl/__main__.py
@@ -15,13 +15,18 @@ def parse_arguments():
     )
 
     parser.add_argument("source_language", help="Source language of your text")
-
     parser.add_argument("target_language", help="Target language of your desired text")
 
+    formality_group = parser.add_mutually_exclusive_group()
+    formality_group.add_argument(
+        "--formal", help="Use formal tone in translation", action="store_true"
+    )
+    formality_group.add_argument(
+        "--informal", help="Use informal tone in translation", action="store_true"
+    )
+
     input_group = parser.add_mutually_exclusive_group()
-
     input_group.add_argument("-t", "--text", help="Text to be translated")
-
     input_group.add_argument("-f", "--file", help="File to be translated")
 
     return parser.parse_args()
@@ -37,8 +42,14 @@ def main():
     else:
         text = args.text
 
+    kwargs = {}
+    if args.formal:
+        kwargs["formality_tone"] = "formal"
+    if args.informal:
+        kwargs["formality_tone"] = "informal"
+
     try:
-        print(deepl.translate(source_language, target_language, text))
+        print(deepl.translate(source_language, target_language, text, **kwargs))
     except AssertionError as e:
         print(f"Error: {e}")
 

--- a/deepl/generators.py
+++ b/deepl/generators.py
@@ -1,5 +1,5 @@
 from deepl.hacks import generate_timestamp
-from deepl.settings import MAGIC_NUMBER
+from deepl.settings import MAGIC_NUMBER, SUPPORTED_FORMALITY_TONES
 
 
 def generate_split_sentences_request_data(text, identifier=MAGIC_NUMBER, **kwargs):
@@ -30,8 +30,21 @@ def generate_jobs(sentences, beams=1):
     return jobs
 
 
+def generate_common_job_params(formality_tone):
+    if not formality_tone:
+        return {}
+    if formality_tone not in SUPPORTED_FORMALITY_TONES:
+        raise ValueError(f"Formality tone '{formality_tone}' not supported.")
+    return {"formality": formality_tone}
+
+
 def generate_translation_request_data(
-    source_language, target_language, sentences, identifier=MAGIC_NUMBER, alternatives=1
+    source_language,
+    target_language,
+    sentences,
+    identifier=MAGIC_NUMBER,
+    alternatives=1,
+    formality_tone=None,
 ):
     return {
         "jsonrpc": "2.0",
@@ -44,7 +57,7 @@ def generate_translation_request_data(
                 "target_lang": target_language,
             },
             "priority": 1,
-            "commonJobParams": {},
+            "commonJobParams": generate_common_job_params(formality_tone),
             "timestamp": generate_timestamp(sentences),
         },
         "id": identifier,

--- a/deepl/settings.py
+++ b/deepl/settings.py
@@ -28,3 +28,5 @@ SUPPORTED_LANGUAGES = [
     {"code": "ES", "language": "Spanish"},
     {"code": "SV", "language": "Swedish"},
 ]
+
+SUPPORTED_FORMALITY_TONES = ["formal", "informal"]

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,3 +1,4 @@
+import pytest
 from essential_generators import DocumentGenerator
 
 from deepl.api import translate
@@ -53,3 +54,22 @@ def test_translate_generated_paragraph():
     text = generator.paragraph()
     translation = translate("EN", "DE", text)
     assert len(translation) > 1
+
+
+def test_formal_german_translation():
+    text = "What's your name?"
+    expected_translations = ["Wie ist Ihr Name?", "Wie heißen Sie?"]
+    translation = translate("EN", "DE", text, formality_tone="formal")
+    assert translation in expected_translations
+
+
+def test_informal_german_translation():
+    text = "What's your name?"
+    expected_translations = ["Wie ist dein Name?", "Wie heißt du?"]
+    translation = translate("EN", "DE", text, formality_tone="informal")
+    assert translation in expected_translations
+
+
+def test_invalid_formal_tone():
+    with pytest.raises(ValueError):
+        translate("EN", "DE", "ABC", formality_tone="politically incorrect")


### PR DESCRIPTION
Closes https://github.com/ptrstn/deepl-translate/issues/10

Adds a new parameter ```formality_tone``` with possible values: 
- ```formal``` for informal tone 
- ```informal``` for formal tone

Also adds two new optional command line arguments:
- ```--formal``` for formal tone
- ```--informal``` for informal tone
